### PR TITLE
Improve text viewer performance & plugin interface

### DIFF
--- a/file-commander-core/file-commander-core.pro
+++ b/file-commander-core/file-commander-core.pro
@@ -66,12 +66,12 @@ mac* | linux* {
 	QMAKE_CXXFLAGS_WARN_ON = -Wall -Wno-c++11-extensions -Wno-local-type-template-args -Wno-deprecated-register
 }
 
-LIBS += -L../bin -lqtutils
+LIBS += -L$${DESTDIR} -lcpputils -lqtutils
 
 win32*:!*msvc2012:*msvc* {
 	QMAKE_CXXFLAGS += /FS
 }
 
 mac*|linux*{
-	PRE_TARGETDEPS += $${DESTDIR}/libqtutils.a
+	PRE_TARGETDEPS += $${DESTDIR}/libqtutils.a $${DESTDIR}/libcpputils.a
 }

--- a/file-commander-core/src/pluginengine/cpluginengine.cpp
+++ b/file-commander-core/src/pluginengine/cpluginengine.cpp
@@ -105,8 +105,8 @@ void CPluginEngine::viewCurrentFile()
 	{
 		viewerWindow->setAutoDeleteOnClose(true);
 		viewerWindow->showNormal();
-		viewerWindow->raise();
 		viewerWindow->activateWindow();
+		viewerWindow->raise();
 	}
 }
 

--- a/file-commander-core/src/pluginengine/cpluginengine.cpp
+++ b/file-commander-core/src/pluginengine/cpluginengine.cpp
@@ -128,7 +128,7 @@ CFileCommanderViewerPlugin *CPluginEngine::viewerForCurrentFile()
 	{
 		if (plugin.first->type() == CFileCommanderPlugin::Viewer)
 		{
-			CFileCommanderViewerPlugin * viewer = dynamic_cast<CFileCommanderViewerPlugin*>(plugin.first.get());
+			CFileCommanderViewerPlugin * viewer = static_cast<CFileCommanderViewerPlugin*>(plugin.first.get());
 			assert(viewer);
 			if (viewer && viewer->canViewCurrentFile())
 				return viewer;

--- a/file-commander-core/src/pluginengine/cpluginengine.cpp
+++ b/file-commander-core/src/pluginengine/cpluginengine.cpp
@@ -100,7 +100,7 @@ void CPluginEngine::currentPanelChanged(Panel p)
 
 void CPluginEngine::viewCurrentFile()
 {
-	CPluginWindow * viewerWindow = dynamic_cast<CPluginWindow*>(createViewerWindowForCurrentFile());
+	CPluginWindow * viewerWindow = createViewerWindowForCurrentFile();
 	if (viewerWindow)
 	{
 		viewerWindow->setAutoDeleteOnClose(true);
@@ -110,7 +110,7 @@ void CPluginEngine::viewCurrentFile()
 	}
 }
 
-QMainWindow *CPluginEngine::createViewerWindowForCurrentFile()
+CPluginWindow *CPluginEngine::createViewerWindowForCurrentFile()
 {
 	auto viewer = viewerForCurrentFile();
 	return viewer ? viewer->viewCurrentFile() : nullptr;

--- a/file-commander-core/src/pluginengine/cpluginengine.h
+++ b/file-commander-core/src/pluginengine/cpluginengine.h
@@ -9,8 +9,8 @@
 
 
 class CFileCommanderViewerPlugin;
+class CPluginWindow;
 class QLibrary;
-class QMainWindow;
 
 class CPluginEngine : public PanelContentsChangedListener
 {
@@ -30,7 +30,7 @@ public:
 
 // Operations
 	void viewCurrentFile();
-	QMainWindow * createViewerWindowForCurrentFile();
+	CPluginWindow* createViewerWindowForCurrentFile();
 
 private:
 	CPluginEngine();

--- a/file-commander-core/src/plugininterface/cpluginwindow.cpp
+++ b/file-commander-core/src/plugininterface/cpluginwindow.cpp
@@ -1,25 +1,24 @@
 #include "cpluginwindow.h"
 
-CPluginWindow::CPluginWindow(QWidget *parent) :
-	QMainWindow(parent),
-	_bAutoDeleteOnClose(false)
+DISABLE_COMPILER_WARNINGS
+#include <QApplication>
+RESTORE_COMPILER_WARNINGS
+
+CPluginWindow::CPluginWindow() :
+	QMainWindow(appMainWindow(), Qt::Dialog)
 {
+	setAttribute(Qt::WA_WindowPropagation);
 }
 
-bool CPluginWindow::autoDeleteOnClose() const
+QMainWindow* CPluginWindow::appMainWindow()
 {
-	return _bAutoDeleteOnClose;
-}
+	QList<QWidget*> widgets = qApp->topLevelWidgets();
+	foreach (QWidget* mw, widgets) {
+		if (mw->objectName() == QLatin1Literal("CMainWindow")) {
+			return static_cast<QMainWindow*>(mw);
+		}
+	}
 
-void CPluginWindow::setAutoDeleteOnClose(bool autoDelete)
-{
-	_bAutoDeleteOnClose = autoDelete;
-}
-
-void CPluginWindow::closeEvent(QCloseEvent* event)
-{
-	if (event && _bAutoDeleteOnClose)
-		deleteLater();
-
-	QMainWindow::closeEvent(event);
+	Q_ASSERT(false);
+	return nullptr;
 }

--- a/file-commander-core/src/plugininterface/cpluginwindow.h
+++ b/file-commander-core/src/plugininterface/cpluginwindow.h
@@ -13,16 +13,23 @@ class PLUGIN_EXPORT CPluginWindow : public QMainWindow
 	Q_OBJECT
 
 public:
-	explicit CPluginWindow(QWidget *parent = 0);
+	static QMainWindow* appMainWindow();
+
+public:
+	CPluginWindow();
 
 	bool autoDeleteOnClose() const;
 	void setAutoDeleteOnClose(bool autoDelete);
-
-protected:
-	virtual void closeEvent(QCloseEvent* event) override;
-
-private:
-	bool _bAutoDeleteOnClose;
 };
+
+inline bool CPluginWindow::autoDeleteOnClose() const
+{
+	return testAttribute(Qt::WA_DeleteOnClose);
+}
+
+inline void CPluginWindow::setAutoDeleteOnClose(bool autoDelete)
+{
+	setAttribute(Qt::WA_DeleteOnClose, autoDelete);
+}
 
 #endif // CVIEWERWINDOW_H

--- a/file-commander.pro
+++ b/file-commander.pro
@@ -1,22 +1,11 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
-SUBDIRS += qtutils text_encoding_detector file_commander_core imageviewerplugin textviewerplugin qt_app cpputils
-
-qtutils.subdir = qtutils cpputils
-
-file_commander_core.subdir = file-commander-core
-file_commander_core.depends = qtutils
-
-imageviewerplugin.subdir = plugins/viewer/imageviewer
-imageviewerplugin.depends = file_commander_core
-
-textviewerplugin.subdir = plugins/viewer/textviewer
-textviewerplugin.depends = file_commander_core text_encoding_detector
-
-text_encoding_detector.subdir = text-encoding-detector/text-encoding-detector cpputils
-
-qt_app.subdir  = qt-app
-qt_app.depends = file_commander_core qtutils imageviewerplugin textviewerplugin
-
-cpputils.subdir = cpputils
+SUBDIRS += \
+    cpputils \
+    qtutils \
+    file-commander-core \
+    text-encoding-detector \
+    plugins/viewer/imageviewer \
+    plugins/viewer/textviewer \
+    qt-app

--- a/plugins/viewer/imageviewer/src/cimageviewerwindow.cpp
+++ b/plugins/viewer/imageviewer/src/cimageviewerwindow.cpp
@@ -7,8 +7,8 @@ DISABLE_COMPILER_WARNINGS
 #include <QShortcut>
 RESTORE_COMPILER_WARNINGS
 
-CImageViewerWindow::CImageViewerWindow(QWidget *parent) :
-	CPluginWindow(parent),
+CImageViewerWindow::CImageViewerWindow() :
+	CPluginWindow(),
 	ui(new Ui::CImageViewerWindow)
 {
 	ui->setupUi(this);

--- a/plugins/viewer/imageviewer/src/cimageviewerwindow.h
+++ b/plugins/viewer/imageviewer/src/cimageviewerwindow.h
@@ -14,7 +14,7 @@ class CImageViewerWindow : public CPluginWindow
 	Q_OBJECT
 
 public:
-	explicit CImageViewerWindow(QWidget *parent = 0);
+	CImageViewerWindow();
 	~CImageViewerWindow();
 
 	bool displayImage(const QString& imagePath, const QImage& image = QImage());

--- a/plugins/viewer/textviewer/src/ctextviewerwindow.cpp
+++ b/plugins/viewer/textviewer/src/ctextviewerwindow.cpp
@@ -71,7 +71,7 @@ bool CTextViewerWindow::asDetectedAutomatically()
 	QByteArray data;
 	if (!readSource(data))
 	{
-		QMessageBox::warning(dynamic_cast<QWidget*>(parent()), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
+		QMessageBox::warning(parentWidget(), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
 		return false;
 	}
 
@@ -102,7 +102,7 @@ bool CTextViewerWindow::asSystemDefault()
 	QByteArray data;
 	if (!readSource(data))
 	{
-		QMessageBox::warning(dynamic_cast<QWidget*>(parent()), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
+		QMessageBox::warning(parentWidget(), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
 		return false;
 	}
 
@@ -117,7 +117,7 @@ bool CTextViewerWindow::asUtf8()
 	QByteArray data;
 	if (!readSource(data))
 	{
-		QMessageBox::warning(dynamic_cast<QWidget*>(parent()), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
+		QMessageBox::warning(parentWidget(), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
 		return false;
 	}
 
@@ -132,7 +132,7 @@ bool CTextViewerWindow::asUtf16()
 	QByteArray data;
 	if (!readSource(data))
 	{
-		QMessageBox::warning(dynamic_cast<QWidget*>(parent()), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
+		QMessageBox::warning(parentWidget(), tr("Failed to read the file"), tr("Failed to load the file\n\n%1\n\nIt is inaccessible or doesn't exist.").arg(_sourceFilePath));
 		return false;
 	}
 

--- a/plugins/viewer/textviewer/src/ctextviewerwindow.h
+++ b/plugins/viewer/textviewer/src/ctextviewerwindow.h
@@ -6,6 +6,8 @@
 
 #include "ui_ctextviewerwindow.h"
 
+#include <QPlainTextEdit>
+
 class CTextViewerWindow : public CPluginWindow, private Ui::CTextViewerWindow
 {
 	Q_OBJECT
@@ -29,8 +31,9 @@ private:
 	bool readSource(QByteArray& data) const;
 
 private:
-	CFindDialog            _findDialog;
-	QString                _sourceFilePath;
+	QPlainTextEdit	_textBrowser;
+	CFindDialog		_findDialog;
+	QString			_sourceFilePath;
 };
 
 #endif // CTEXTVIEWERWINDOW_H

--- a/plugins/viewer/textviewer/src/ctextviewerwindow.h
+++ b/plugins/viewer/textviewer/src/ctextviewerwindow.h
@@ -4,17 +4,14 @@
 #include "plugininterface/cpluginwindow.h"
 #include "cfinddialog.h"
 
-namespace Ui {
-class CTextViewerWindow;
-}
+#include "ui_ctextviewerwindow.h"
 
-class CTextViewerWindow : public CPluginWindow
+class CTextViewerWindow : public CPluginWindow, private Ui::CTextViewerWindow
 {
 	Q_OBJECT
 
 public:
-	explicit CTextViewerWindow(QWidget *parent = 0);
-	~CTextViewerWindow();
+	CTextViewerWindow();
 
 	bool loadTextFile(const QString& file);
 
@@ -34,7 +31,6 @@ private:
 private:
 	CFindDialog            _findDialog;
 	QString                _sourceFilePath;
-	Ui::CTextViewerWindow *ui;
 };
 
 #endif // CTEXTVIEWERWINDOW_H

--- a/plugins/viewer/textviewer/src/ctextviewerwindow.ui
+++ b/plugins/viewer/textviewer/src/ctextviewerwindow.ui
@@ -18,18 +18,7 @@
     <normaloff>:/main_icon</normaloff>:/main_icon</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QTextBrowser" name="textBrowser">
-      <property name="textInteractionFlags">
-       <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-      </property>
-      <property name="openExternalLinks">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-   </layout>
+   <layout class="QVBoxLayout" name="verticalLayout"/>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -37,7 +26,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuView">

--- a/qt-app/src/cmainwindow.cpp
+++ b/qt-app/src/cmainwindow.cpp
@@ -1,4 +1,5 @@
 #include "cmainwindow.h"
+#include "plugininterface/cpluginwindow.h"
 #include "progressdialogs/ccopymovedialog.h"
 #include "progressdialogs/cdeleteprogressdialog.h"
 #include "progressdialogs/cfileoperationconfirmationprompt.h"
@@ -678,7 +679,7 @@ void CMainWindow::quickViewCurrentFile()
 		emit fileQuickVewFinished();
 	}
 
-	QMainWindow * viewerWindow = CPluginEngine::get().createViewerWindowForCurrentFile();
+	CPluginWindow * viewerWindow = CPluginEngine::get().createViewerWindowForCurrentFile();
 	if (!viewerWindow)
 		return;
 

--- a/qt-app/src/main.cpp
+++ b/qt-app/src/main.cpp
@@ -46,7 +46,7 @@ bool CFileCommanderApplication::notify(QObject *receiver, QEvent *e)
 	// A dirty hack to implement switching between left and right panels on Tab key press
 	if (e && e->type() == QEvent::KeyPress)
 	{
-		QKeyEvent * keyEvent = dynamic_cast<QKeyEvent*>(e);
+		QKeyEvent * keyEvent = static_cast<QKeyEvent*>(e);
 		if (keyEvent && keyEvent->key() == Qt::Key_Tab && _mainWindow)
 		{
 			_mainWindow->tabKeyPressed();

--- a/qt-app/src/panel/cpanelwidget.cpp
+++ b/qt-app/src/panel/cpanelwidget.cpp
@@ -780,7 +780,7 @@ bool CPanelWidget::eventFilter(QObject * object, QEvent * e)
 	}
 	else if(e->type() == QEvent::Wheel && object == ui->_list->viewport())
 	{
-		QWheelEvent * wEvent = dynamic_cast<QWheelEvent*>(e);
+		QWheelEvent * wEvent = static_cast<QWheelEvent*>(e);
 		if (wEvent && wEvent->modifiers() == Qt::ShiftModifier)
 		{
 			if (wEvent->delta() > 0)


### PR DESCRIPTION
fix issue #59

- [x] Use a minimal, but fast text viewer.
    - [ ] Switch the text viewer depending on the source file's mime type.
- [x] Plugin windows always have the application window as parent.
- [x] Use native "delete-on-close".
- [ ] Resolve parent of warning messages.

@VioletGiraffe This is :construction: WIP (work in progress), but compilable to check things out. Can you please check, if ...
* ... the plugin window appears centered to the main window?
* ... the 14M test file displays fast on Windows?

Further the methods need to become more atomic. That means, the following code needs to be split up:

```c++
CPluginWindow * CTextViewerPlugin::viewCurrentFile() {
    CTextViewerWindow* w = new CTextViewerWindow;
    
    /* This method should actually ONLY return the created widget instance.
       The following code causes a lot of headaches, as it aggressively tries to hide the widget and shows messages through complex code paths - and this is one reason, why every message/dialog is misplaced on screen (e.g. main window position suddenly becomes P(0,0) instead of the actual position) etc. */

    if (!load(/*fileName*/)) {
        delete w; w = nullptr;
    }

    return w;
}
```

Ideas?