### PR TITLE
disable selection without key-modifiers

### DIFF
--- a/qt-app/src/cmainwindow.cpp
+++ b/qt-app/src/cmainwindow.cpp
@@ -207,6 +207,8 @@ void CMainWindow::initActions()
 	connect(ui->actionQuick_view, &QAction::triggered, this, &CMainWindow::toggleQuickView);
 
 	connect(ui->action_Invert_selection, &QAction::triggered, this, &CMainWindow::invertSelection);
+    connect(ui->actionSelect_all, &QAction::triggered, this, &CMainWindow::selectAll);
+    connect(ui->actionClear_selection, &QAction::triggered, this, &CMainWindow::clearSelection);
 
 	connect(ui->actionFull_screen_mode, &QAction::toggled, this, &CMainWindow::toggleFullScreenMode);
 	connect(ui->actionTablet_mode, &QAction::toggled, this, &CMainWindow::toggleTabletMode);
@@ -512,6 +514,18 @@ void CMainWindow::invertSelection()
 {
 	if (_currentFileList)
 		_currentFileList->invertSelection();
+}
+
+void CMainWindow::selectAll()
+{
+    if (_currentFileList)
+        _currentFileList->selectAll();
+}
+
+void CMainWindow::clearSelection()
+{
+    if (_currentFileList)
+        _currentFileList->clearSelection();
 }
 
 // Other UI commands

--- a/qt-app/src/cmainwindow.h
+++ b/qt-app/src/cmainwindow.h
@@ -70,6 +70,8 @@ private slots: // UI slots
 
 // Selection slots
 	void invertSelection();
+    void selectAll();
+    void clearSelection();
 
 // Other UI commands
 	void viewFile();

--- a/qt-app/src/cmainwindow.ui
+++ b/qt-app/src/cmainwindow.ui
@@ -262,6 +262,8 @@
      <string>&amp;Selection</string>
     </property>
     <addaction name="action_Invert_selection"/>
+    <addaction name="actionSelect_all"/>
+    <addaction name="actionClear_selection"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -404,6 +406,22 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+C</string>
+   </property>
+  </action>
+  <action name="actionSelect_all">
+   <property name="text">
+    <string>Select all</string>
+   </property>
+   <property name="shortcut">
+    <string>+</string>
+   </property>
+  </action>
+  <action name="actionClear_selection">
+   <property name="text">
+    <string>Clear selection</string>
+   </property>
+   <property name="shortcut">
+    <string>-</string>
    </property>
   </action>
  </widget>

--- a/qt-app/src/panel/cpanelwidget.cpp
+++ b/qt-app/src/panel/cpanelwidget.cpp
@@ -410,7 +410,7 @@ void CPanelWidget::selectionChanged(const QItemSelection& selected, const QItemS
 		}
 	}
 
-	const auto selection = selectedItemsHashes();
+    const auto selection = selectedItemsHashes(true);
 	// Updating the selection summary label
 	updateInfoLabel(selection);
 
@@ -936,6 +936,16 @@ qulonglong CPanelWidget::currentItemHash() const
 void CPanelWidget::invertSelection()
 {
 	ui->_list->invertSelection();
+}
+
+void CPanelWidget::selectAll()
+{
+    ui->_list->selectAll();
+}
+
+void CPanelWidget::clearSelection()
+{
+    ui->_list->clearSelection();
 }
 
 void CPanelWidget::onSettingsChanged()

--- a/qt-app/src/panel/cpanelwidget.h
+++ b/qt-app/src/panel/cpanelwidget.h
@@ -66,6 +66,8 @@ public:
 	std::vector<qulonglong> selectedItemsHashes(bool onlyHighlightedItems = false) const;
 	qulonglong currentItemHash() const;
 	void invertSelection();
+    void selectAll();
+    void clearSelection();
 
 	void onSettingsChanged();
 

--- a/qt-app/src/panel/filelistwidget/cfilelistview.cpp
+++ b/qt-app/src/panel/filelistwidget/cfilelistview.cpp
@@ -103,12 +103,6 @@ void CFileListView::invertSelection()
 	selectionModel()->select(allItems, QItemSelectionModel::Toggle | QItemSelectionModel::Rows);
 }
 
-void CFileListView::selectAll()
-{
-    QItemSelection allItems(model()->index(0, 0), model()->index(model()->rowCount() - 1, 0));
-    selectionModel()->select(allItems, QItemSelectionModel::Select | QItemSelectionModel::Rows);
-}
-
 void CFileListView::clearSelection()
 {
     QItemSelection allItems(model()->index(0, 0), model()->index(model()->rowCount() - 1, 0));

--- a/qt-app/src/panel/filelistwidget/cfilelistview.h
+++ b/qt-app/src/panel/filelistwidget/cfilelistview.h
@@ -50,6 +50,8 @@ public:
 	void restoreHeaderState();
 
 	void invertSelection();
+    void selectAll();
+    void clearSelection();
 
 	void modelAboutToBeReset();
 

--- a/qt-app/src/panel/filelistwidget/cfilelistview.h
+++ b/qt-app/src/panel/filelistwidget/cfilelistview.h
@@ -50,7 +50,6 @@ public:
 	void restoreHeaderState();
 
 	void invertSelection();
-    void selectAll();
     void clearSelection();
 
 	void modelAboutToBeReset();


### PR DESCRIPTION
https://github.com/VioletGiraffe/file-commander/issues/212
With separate selection we shouldn't change selection on mouse button without key-modifiers. (The same in Total Commander and Midnight Commander)
With this approach it's hard to reset a selection. That's why I've added select/deselect all.