### PR TITLE
fix path for qt creator output folder

### DIFF
--- a/qt-app/qt-app.pro
+++ b/qt-app/qt-app.pro
@@ -140,7 +140,7 @@ mac*{
 
 	LIBS += -framework AppKit
 
-	QMAKE_POST_LINK = cp -f -p $$PWD/$$DESTDIR/*.dylib $$PWD/$$DESTDIR/$${TARGET}.app/Contents/MacOS/
+        QMAKE_POST_LINK = cp -f -p $$OUT_PWD/$$DESTDIR/*.dylib $$OUT_PWD/$$DESTDIR/$${TARGET}.app/Contents/MacOS/
 }
 
 linux*|mac*|freebsd{


### PR DESCRIPTION
Qt Creator uses separate folder for output files. It's accessible with $$OUT_PWD variable.