### PR TITLE
remove limit to avoid redundant activity

### DIFF
--- a/qt-app/src/panel/cpanelwidget.cpp
+++ b/qt-app/src/panel/cpanelwidget.cpp
@@ -966,7 +966,7 @@ void CPanelWidget::updateCurrentDiskButton()
 			const auto diskInfo = _controller->volumeEnumerator().drives()[id];
 			_currentDisk = diskInfo.rootObjectInfo.fullAbsolutePath();
 			ui->_driveInfoLabel->setText(tr("%1 (%2): <b>%4 free</b> of %5 total").
-				arg(diskInfo.volumeLabel, diskInfo.fileSystemName, fileSizeToString(diskInfo.freeSize, 'M', " "), fileSizeToString(diskInfo.volumeSize, 'M', " ")));
+                arg(diskInfo.volumeLabel, diskInfo.fileSystemName, fileSizeToString(diskInfo.freeSize, 0, " "), fileSizeToString(diskInfo.volumeSize, 0, " ")));
 
 			return;
 		}


### PR DESCRIPTION
Disk space in MB causes redundant activity on the screen. 
The size insignificantly changed from time to time by background processes. And it can distract.
In GB we won't see these changes.