### PR TITLE
typo: Seacrh in Search Dialog

### DIFF
--- a/qt-app/src/filessearchdialog/cfilessearchwindow.ui
+++ b/qt-app/src/filessearchdialog/cfilessearchwindow.ui
@@ -73,7 +73,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Seacrh for</string>
+         <string>Search for</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
<img width="213" alt="Screenshot 2024-07-01 at 10 35 14 PM" src="https://github.com/VioletGiraffe/file-commander/assets/20785524/c4e250ce-3855-426c-a567-dc0b1001d60f">


Love your work. Thank you.